### PR TITLE
Update for base-4.8 support and add HasNew in addition to HasGet/HasPut.

### DIFF
--- a/Control/Monad/StateVar.hs
+++ b/Control/Monad/StateVar.hs
@@ -10,7 +10,9 @@ module Control.Monad.StateVar (
     -- * Overloaded get and put
     HasGet(..),
     HasPut(..),
+    HasNew(..),
     put',
+    new',
     modify,
     modify',
     swap,
@@ -24,7 +26,7 @@ module Control.Monad.StateVar (
 ) where
 
 import Control.Monad.Trans.Class
-import GHC.Conc (STM, TVar, readTVar, writeTVar)
+import GHC.Conc (STM, TVar, readTVar, writeTVar, newTVar)
 -- import Control.Concurrent.STM
 import Data.IORef
 
@@ -47,6 +49,10 @@ class HasPut m v where
     -- | Write a new value to the variable.
     put :: v a -> a -> m ()
 
+class HasNew m v where
+    -- | Create a new variable.
+    new :: a -> m (v a)
+
 -- | 'lift' $ 'get' v
 instance (HasGet m v, MonadTrans t, Monad m) => HasGet (t m) v where
     get v = lift $ get v
@@ -56,6 +62,11 @@ instance (HasGet m v, MonadTrans t, Monad m) => HasGet (t m) v where
 instance (HasPut m v, MonadTrans t, Monad m) => HasPut (t m) v where
     put v a = lift $ put v a
     {-# INLINE put #-}
+
+-- | 'lift' $ 'put' v a
+instance (HasNew m v, MonadTrans t, Monad m) => HasNew (t m) v where
+    new a = lift $ new a
+    {-# INLINE new #-}
 
 -- | 'readIORef'
 instance HasGet IO IORef where
@@ -67,6 +78,11 @@ instance HasPut IO IORef where
     put = writeIORef
     {-# INLINE put #-}
 
+-- | 'newIORef'
+instance HasNew IO IORef where
+    new = newIORef
+    {-# INLINE new #-}
+
 -- | 'readTVar'
 instance HasGet STM TVar where
     get = readTVar
@@ -76,6 +92,11 @@ instance HasGet STM TVar where
 instance HasPut STM TVar where
     put = writeTVar
     {-# INLINE put #-}
+
+-- | 'newTVar'
+instance HasNew STM TVar where
+    new = newTVar
+    {-# INLINE new #-}
 
 -- | 'S.readSTRef'
 instance HasGet (S.ST s) (STRef s) where
@@ -87,6 +108,11 @@ instance HasPut (S.ST s) (STRef s) where
     put = S.writeSTRef
     {-# INLINE put #-}
 
+-- | 'S.newSTRef'
+instance HasNew (S.ST s) (STRef s) where
+    new = S.newSTRef
+    {-# INLINE new #-}
+
 -- | 'L.readSTRef'
 instance HasGet (L.ST s) (STRef s) where
     get = L.readSTRef
@@ -97,10 +123,20 @@ instance HasPut (L.ST s) (STRef s) where
     put = L.writeSTRef
     {-# INLINE put #-}
 
+-- | 'L.newSTRef'
+instance HasNew (L.ST s) (STRef s) where
+    new = L.newSTRef
+    {-# INLINE new #-}
+
 -- | Variant of 'put' that forces the value before writing it.
 put' :: HasPut m v => v a -> a -> m ()
 put' v x = x `seq` put v x
 {-# INLINE put' #-}
+
+-- | Variant of 'new' that forces the value before creating a variable with it.
+new' :: HasNew m v => a -> m (v a)
+new' x = x `seq` new x
+{-# INLINE new' #-}
 
 -- | Modify the value inside the variable with the given function.
 --
@@ -122,9 +158,9 @@ modify' v f = do
 
 -- | Write a new value and return the old value.
 swap :: (HasGet m v, HasPut m v, Monad m) => v a -> a -> m a
-swap var new = do
+swap var newVal = do
     old <- get var
-    put var new
+    put var newVal
     return old
 {-# INLINE swap #-}
 

--- a/Control/Monad/StateVar.hs
+++ b/Control/Monad/StateVar.hs
@@ -28,7 +28,7 @@ import GHC.Conc (STM, TVar, readTVar, writeTVar)
 -- import Control.Concurrent.STM
 import Data.IORef
 
-#if MIN_VERSION_base(4,4,0)
+#if MIN_VERSION_base(4,4,0) && !MIN_VERSION_base(4,8,0)
 import qualified Control.Monad.ST.Safe as S
 import qualified Control.Monad.ST.Lazy.Safe as L
 #else

--- a/monad-statevar.cabal
+++ b/monad-statevar.cabal
@@ -1,5 +1,5 @@
 name:                monad-statevar
-version:             0.1
+version:             0.1.1
 synopsis:            Concise, overloaded accessors for IORef, STRef, TVar
 description:
     Overloaded 'get' and 'put' for state variables ('IORef', 'STRef', 'TVar')

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -8,7 +8,6 @@ import Control.Monad.StateVar
 import Control.Concurrent.STM
 import Data.IORef
 import Data.STRef
-import qualified Data.STRef.Lazy as L
 import Control.Exception
 import Control.Monad.ST
 import qualified Control.Monad.ST.Lazy as L
@@ -73,7 +72,7 @@ testStateVar var = do
 
 testIORef :: IO ()
 testIORef = do
-    var <- newIORef (5 :: Int)
+    var <- new 5 :: IO (IORef Int)
     5 <- get var
     put var 6
     6 <- get var
@@ -84,7 +83,7 @@ testIORef = do
 testSTRef :: IO ()
 testSTRef = do
     9 <- return $ runST $ do
-        var <- newSTRef (5 :: Int)
+        var <- new 5 :: ST s (STRef s Int)
         5 <- get var
         put var 6
         6 <- get var
@@ -95,10 +94,10 @@ testSTRef = do
 main :: IO ()
 main = do
     testSafe
-    newIORef 0 >>= testStateVar
-    atomically $ newTVar 0 >>= testStateVar
-    () <- return $ runST $ newSTRef 0 >>= testStateVar
-    () <- return $ L.runST $ L.newSTRef 0 >>= testStateVar
+    new 0 >>= testStateVar
+    atomically $ new 0 >>= testStateVar
+    () <- return $ runST $ new 0 >>= testStateVar
+    () <- return $ L.runST $ new 0 >>= testStateVar
     testIORef
     testSTRef
 


### PR DESCRIPTION
This useful for libraries that can become completely polymorphic about which monad and reference type they use under the hood (similar to the vector classes in the "vector" package).
